### PR TITLE
Skeleton project to build using cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(obdii-query)
+find_package(Qt5Core REQUIRED)
+add_executable( carcomm src/main.cpp )
+target_link_libraries(carcomm Qt5::Core)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main(void) {
+    std::cout << "It works!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
```
If you have cmake installed on windows along with Qt Creator, this CMakeLists.txt file can be opened and used directly in the IDE to build this project.  This is something we would like to keep working across releases and during development.  Using Qt Creator, should be a primary target of building this software.
```
